### PR TITLE
Render Assets

### DIFF
--- a/lib/dogear/bookmarks.ex
+++ b/lib/dogear/bookmarks.ex
@@ -4,6 +4,7 @@ defmodule Dogear.Bookmarks do
   """
 
   import Ecto.Query, warn: false
+  alias Ecto.Query
   alias Dogear.Repo
 
   alias Dogear.Books.Spines
@@ -12,7 +13,7 @@ defmodule Dogear.Bookmarks do
   alias Dogear.Schema.Bookmark
 
   def get_latest_bookmark() do
-    case list_bookmarks() do
+    case list_bookmarks(order_by: [desc: :updated_at]) do
       [head | _] -> {:ok, head}
       [] -> {:error, "No bookmark"}
     end
@@ -51,8 +52,18 @@ defmodule Dogear.Bookmarks do
       [%Bookmark{}, ...]
 
   """
-  def list_bookmarks do
-    Repo.all(Bookmark)
+  def list_bookmarks(query_opts \\ []) do
+    Bookmark
+    |> query(query_opts)
+    |> Repo.all()
+  end
+
+  def query(queryable, []), do: queryable
+
+  def query(queryable, [{:order_by, order_by} | tail]) do
+    queryable
+    |> Query.order_by(^order_by)
+    |> query(tail)
   end
 
   @doc """

--- a/lib/dogear/bookmarks.ex
+++ b/lib/dogear/bookmarks.ex
@@ -54,17 +54,16 @@ defmodule Dogear.Bookmarks do
   """
   def list_bookmarks(query_opts \\ []) do
     Bookmark
-    |> query(query_opts)
+    |> compose_query(query_opts)
     |> Repo.all()
   end
 
-  def query(queryable, []), do: queryable
-
-  def query(queryable, [{:order_by, order_by} | tail]) do
-    queryable
-    |> Query.order_by(^order_by)
-    |> query(tail)
+  def compose_query(queryable, query_opts) do
+    Enum.reduce(query_opts, queryable, fn query_opt, acc -> query(acc, query_opt) end)
   end
+
+  def query(queryable, {:order_by, order_by}), do:
+    Query.order_by(queryable, ^order_by)
 
   @doc """
   Gets a single bookmark.

--- a/lib/dogear/bookmarks.ex
+++ b/lib/dogear/bookmarks.ex
@@ -9,6 +9,7 @@ defmodule Dogear.Bookmarks do
 
   alias Dogear.Books.Spines
   alias Dogear.Books.Spines.Spine
+  alias Dogear.Books.Manifests.Item
   alias Dogear.Schema.Book
   alias Dogear.Schema.Bookmark
 
@@ -35,12 +36,19 @@ defmodule Dogear.Bookmarks do
     end
   end
 
-  def navigate_bookmark(%Spine{} = spine, %Bookmark{} = bookmark, offset) do
+  def navigate_bookmark(%Spine{} = spine, %Bookmark{} = bookmark, offset)
+      when is_integer(offset) do
     index = bookmark.spine_index + offset
 
     idref = Spines.get_idref(spine, index)
 
     update_bookmark(bookmark, %{anchor_id: "#", idref: idref, spine_index: index})
+  end
+
+  def navigate_bookmark(%Spine{} = spine, %Bookmark{} = bookmark, %Item{} = manifest_item) do
+    index = Spines.get_index(spine, manifest_item.id)
+
+    update_bookmark(bookmark, %{anchor_id: "#", idref: manifest_item.id, spine_index: index})
   end
 
   @doc """
@@ -62,8 +70,7 @@ defmodule Dogear.Bookmarks do
     Enum.reduce(query_opts, queryable, fn query_opt, acc -> query(acc, query_opt) end)
   end
 
-  def query(queryable, {:order_by, order_by}), do:
-    Query.order_by(queryable, ^order_by)
+  def query(queryable, {:order_by, order_by}), do: Query.order_by(queryable, ^order_by)
 
   @doc """
   Gets a single bookmark.

--- a/lib/dogear/books.ex
+++ b/lib/dogear/books.ex
@@ -46,6 +46,16 @@ defmodule Dogear.Books do
   """
   def get_book!(id), do: Book |> Repo.get!(id) |> load_virtual()
 
+  def fetch_book(id) do
+    case Repo.get(Book, id) do
+      %Book{} = book ->
+        {:ok, load_virtual(book)}
+
+      nil ->
+        {:error, %{message: "Book not found", source: :books, code: :e404}}
+    end
+  end
+
   @doc """
   Creates a book.
   """
@@ -117,8 +127,6 @@ defmodule Dogear.Books do
   end
 
   def load_virtual(%Book{} = book) do
-    Logger.warn("Book: #{inspect(book)}")
-
     book
     |> load_zip_handle()
     |> load_root_filename()

--- a/lib/dogear/books/manifests.ex
+++ b/lib/dogear/books/manifests.ex
@@ -20,9 +20,7 @@ defmodule Dogear.Books.Manifests do
 
   @spec get_id(Manifest.t(), String.t()) :: String.t()
   def get_id(%Manifest{} = manifest, href) do
-    %Item{id: id} =
-      manifest.items
-      |> Enum.find(fn %_{href: manifest_href} -> manifest_href == href end)
+    %Item{id: id} = get_item_by_href(%Manifest{} = manifest, href)
 
     id
   end
@@ -35,5 +33,16 @@ defmodule Dogear.Books.Manifests do
       |> Map.fetch!(:href)
 
     manifest.root_path |> Path.join(href) |> Path.relative_to(".")
+  end
+
+  @spec get_item_by_href(Manifest.t(), String.t()) :: Item.t()
+  def get_item_by_href(%Manifest{} = manifest, href) do
+    Enum.find(manifest.items, fn %Item{href: manifest_href} -> manifest_href == href end)
+  end
+
+  @spec get_item_by_idref(Manifest.t(), String.t()) :: Item.t()
+  def get_item_by_idref(%Manifest{} = manifest, id) do
+    manifest.items
+    |> Enum.find(fn %_{id: manifest_id} -> manifest_id == id end)
   end
 end

--- a/lib/dogear/books/manifests/item.ex
+++ b/lib/dogear/books/manifests/item.ex
@@ -3,7 +3,7 @@ defmodule Dogear.Books.Manifests.Item do
 
   defstruct [:id, :href, :media_type]
 
-  @type t :: %{id: String.t(), href: String.t(), media_type: String.t()}
+  @type t :: %__MODULE__{id: String.t(), href: String.t(), media_type: String.t()}
 
   def to_atoms({"id", id}), do: {:id, id}
   def to_atoms({"href", href}), do: {:href, href}

--- a/lib/dogear_web/live/book_live/index.ex
+++ b/lib/dogear_web/live/book_live/index.ex
@@ -39,7 +39,7 @@ defmodule DogearWeb.BookLive.Index do
   def handle_event("read", %{"id" => id}, socket) do
     book = Books.get_book!(id)
 
-    {:noreply, push_redirect(socket, to: Routes.book_show_path(socket, :show, book))}
+    {:noreply, push_redirect(socket, to: Routes.book_show_path(socket, :show, book, []))}
   end
 
   def handle_event("delete", %{"id" => id}, socket) do

--- a/lib/dogear_web/live/book_live/index.html.heex
+++ b/lib/dogear_web/live/book_live/index.html.heex
@@ -34,7 +34,7 @@
 
         <td>
           <span>
-            <%= live_redirect("Read", to: Routes.book_show_path(@socket, :show, book)) %>
+            <%= live_redirect("Read", to: Routes.book_show_path(@socket, :show, book, [])) %>
           </span>
           <span><%= live_patch("Edit", to: Routes.book_index_path(@socket, :edit, book)) %></span>
           <span>

--- a/lib/dogear_web/live/book_live/upload.html.heex
+++ b/lib/dogear_web/live/book_live/upload.html.heex
@@ -46,7 +46,7 @@
 
             <td>
               <span>
-                <%= live_redirect("Read", to: Routes.book_show_path(@socket, :show, book)) %>
+                <%= live_redirect("Read", to: Routes.book_show_path(@socket, :show, book, [])) %>
               </span>
             </td>
           </tr>

--- a/lib/dogear_web/live/bookmark_live/index.ex
+++ b/lib/dogear_web/live/bookmark_live/index.ex
@@ -13,7 +13,7 @@ defmodule DogearWeb.BookmarkLive.Index do
       {:ok, bookmark} ->
         socket =
           socket
-          |> redirect(to: Routes.book_show_path(socket, :show, bookmark.book_id))
+          |> redirect(to: Routes.book_show_path(socket, :show, bookmark.book_id, []))
 
         {:ok, socket}
 

--- a/lib/dogear_web/plug/asset_assigns.ex
+++ b/lib/dogear_web/plug/asset_assigns.ex
@@ -1,0 +1,34 @@
+defmodule DogearWeb.Plug.AssetAssigns do
+  @moduledoc """
+  Loads the book from the id on the path and puts it into conn.assigns.
+
+  Useful because other Plugs expect the book in assigns.
+  """
+
+  import Plug.Conn
+
+  alias Dogear.Books
+  alias Dogear.Books.Manifests.Item
+  alias Dogear.Bookmarks
+  alias Dogear.Books.Manifests
+
+  alias Dogear.Schema.Bookmark
+  alias Dogear.Schema.Bookmark
+
+  def init(opts \\ %{}), do: opts
+
+  def call(conn, _opts) do
+    with %{"id" => id} <- conn.path_params,
+         {:ok, book} <- Books.fetch_book(id),
+         %Bookmark{} = bookmark <- Bookmarks.get_or_create_bookmark_by_book(book) do
+      conn
+      |> assign(:book, book)
+      |> assign(:bookmark, bookmark)
+    else
+      {:error, %{code: :e404}} ->
+        conn
+        |> Phoenix.Controller.render(MyApp.Web.ErrorView, :"404")
+        |> halt()
+    end
+  end
+end

--- a/lib/dogear_web/plug/asset_redirect.ex
+++ b/lib/dogear_web/plug/asset_redirect.ex
@@ -1,0 +1,79 @@
+defmodule DogearWeb.Plug.AssetRedirect do
+  @moduledoc """
+  Matches the manifest href from the bookmark to the URL
+  This allows links and references rom inside the book.
+  """
+
+  require Logger
+
+  import Plug.Conn
+
+  alias Dogear.Zip
+
+  alias DogearWeb.Router.Helpers, as: Routes
+
+  def init(opts \\ %{}), do: opts
+
+  def call(conn, _opts) do
+    case conn.assigns.path_manifest_item do
+      %{media_type: "application/xhtml+xml"} = item ->
+        Logger.info("Matching path for #{inspect(item)}")
+        conn |> match_path()
+
+      %{media_type: _media_type} = item ->
+        Logger.info("Sending raw asset for #{inspect(item)}")
+        conn |> raw_asset_response()
+
+      nil ->
+        conn |> redirect_to_manifest_item_href()
+    end
+  end
+
+  def match_path(conn) do
+    %{id: manifest_item_id, href: manifest_item_href} = conn.assigns.manifest_item
+
+    case conn.assigns.path_manifest_item do
+      %{id: ^manifest_item_id} ->
+        conn
+
+      %{id: _idref} ->
+        conn |> redirect_to_manifest_item_href()
+    end
+  end
+
+  def raw_asset_response(conn) do
+    with %{"href" => [_ | _] = href_glob} <- conn.path_params,
+         path <- Path.join(href_glob) |> Path.relative_to("."),
+         {:ok, binary} = Zip.file(conn.assigns.book.zip_handle, path) do
+      opts = [
+        content_type: conn.assigns.path_manifest_item.media_type,
+        disposition: :inline,
+        filename: path
+      ]
+
+      conn
+      |> Phoenix.Controller.send_download({:binary, binary}, opts)
+      |> halt()
+    else
+      error ->
+        Logger.warn("assert_response failed error:#{inspect(error)}")
+
+        conn
+        |> Phoenix.Controller.render(MyApp.Web.ErrorView, :"404")
+        |> halt()
+    end
+  end
+
+  defp manifest_path_glob(manifest, href) do
+    Path.join(manifest.root_path, href) |> Path.relative_to(".") |> String.split("/")
+  end
+
+  def redirect_to_manifest_item_href(conn) do
+    path_for_glob =
+      manifest_path_glob(conn.assigns.book.manifest, conn.assigns.manifest_item.href)
+
+    Phoenix.Controller.redirect(conn,
+      to: Routes.book_show_path(conn, :show, conn.assigns.book, path_for_glob)
+    )
+  end
+end

--- a/lib/dogear_web/plug/asset_redirect.ex
+++ b/lib/dogear_web/plug/asset_redirect.ex
@@ -44,7 +44,7 @@ defmodule DogearWeb.Plug.AssetRedirect do
   def raw_asset_response(conn) do
     with %{"href" => [_ | _] = href_glob} <- conn.path_params,
          path <- Path.join(href_glob) |> Path.relative_to("."),
-         {:ok, binary} = Zip.file(conn.assigns.book.zip_handle, path) do
+         {:ok, binary} <- Zip.file(conn.assigns.book.zip_handle, path) do
       opts = [
         content_type: conn.assigns.path_manifest_item.media_type,
         disposition: :inline,

--- a/lib/dogear_web/plug/manifest_assigns.ex
+++ b/lib/dogear_web/plug/manifest_assigns.ex
@@ -1,4 +1,7 @@
 defmodule DogearWeb.Plug.ManifestAssigns do
+  @moduledoc """
+  Put Manifest Items from the path and bookmark into the assigns.
+  """
   import Plug.Conn
 
   alias Dogear.Books.Manifests

--- a/lib/dogear_web/plug/manifest_assigns.ex
+++ b/lib/dogear_web/plug/manifest_assigns.ex
@@ -1,0 +1,26 @@
+defmodule DogearWeb.Plug.ManifestAssigns do
+  import Plug.Conn
+
+  alias Dogear.Books.Manifests
+
+  def init(opts \\ %{}), do: opts
+
+  def call(conn, _opts) do
+    %{book: book, bookmark: bookmark} = conn.assigns
+    manifest_item = Manifests.get_item_by_idref(book.manifest, bookmark.idref)
+    path_manifest_item = get_path_manifest_item(conn)
+
+    conn
+    |> assign(:manifest_item, manifest_item)
+    |> assign(:path_manifest_item, path_manifest_item)
+  end
+
+  defp get_path_manifest_item(%{path_params: %{"href" => [_ | _] = href_glob}} = conn) do
+    manifest = conn.assigns.book.manifest
+    href = Path.join(href_glob) |> Path.relative_to(manifest.root_path)
+
+    Manifests.get_item_by_href(manifest, href)
+  end
+
+  defp get_path_manifest_item(_conn), do: nil
+end

--- a/lib/dogear_web/router.ex
+++ b/lib/dogear_web/router.ex
@@ -1,5 +1,10 @@
 defmodule DogearWeb.Router do
   use DogearWeb, :router
+  require Plug.Router
+
+  alias DogearWeb.Plug.AssetAssigns
+  alias DogearWeb.Plug.ManifestAssigns
+  alias DogearWeb.Plug.AssetRedirect
 
   pipeline :browser do
     plug :auth
@@ -15,6 +20,12 @@ defmodule DogearWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :assets do
+    plug AssetAssigns
+    plug ManifestAssigns
+    plug AssetRedirect
+  end
+
   scope "/", DogearWeb do
     pipe_through :browser
 
@@ -23,9 +34,14 @@ defmodule DogearWeb.Router do
     live "/books", BookLive.Index, :index
     live "/books/new", BookLive.Upload, :new
     live "/books/:id/edit", BookLive.Index, :edit
-
-    live "/books/:id", BookLive.Show, :show
     live "/books/:id/show/edit", BookLive.Show, :edit
+
+    scope "/books/:id" do
+      pipe_through :assets
+
+      # live "/read/", BookLive.Show, :show
+      live "/read/*href", BookLive.Show, :show
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Dogear.MixProject do
   def application do
     [
       mod: {Dogear.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :os_mon]
     ]
   end
 


### PR DESCRIPTION
This allows books to use their own css and images. 
A pipeline is introduced that looks through the manifest for a requested asset. It serves up that asset from the epub if it exists.

There are some unresolved issues here still. We want links in the book to work, but some books have strange structures that make this difficult.